### PR TITLE
fix(import) => Problem with `webpack` build to use library in `SSR` for front-end applications like Angular

### DIFF
--- a/createRequest.js
+++ b/createRequest.js
@@ -1,6 +1,6 @@
 const path = require('path')
 
-const CentraRequest = require('./model/CentraRequest.js'))
+const CentraRequest = require('./model/CentraRequest.js')
 
 module.exports = (url, method) => {
 	return new CentraRequest(url, method)

--- a/createRequest.js
+++ b/createRequest.js
@@ -1,6 +1,6 @@
 const path = require('path')
 
-const CentraRequest = require(path.join(__dirname, 'model', 'CentraRequest.js'))
+const CentraRequest = require('./model/CentraRequest.js'))
 
 module.exports = (url, method) => {
 	return new CentraRequest(url, method)

--- a/model/CentraRequest.js
+++ b/model/CentraRequest.js
@@ -5,7 +5,7 @@ const qs = require('querystring')
 const zlib = require('zlib')
 const {URL} = require('url')
 
-const CentraResponse = require(path.join(__dirname, 'CentraResponse.js'))
+const CentraResponse = require('./CentraResponse.js')
 
 const supportedCompressions = ['gzip', 'deflate']
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "centra",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "centra",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "The core lightweight HTTP client for Node",
   "main": "createRequest.js",
   "scripts": {


### PR DESCRIPTION
Fix import to allow build of application with `webpack`. If we let like this, execution of script through `webpack` failed because module can't be found with the given path `__dirname`.