### PR TITLE
fix: allow for brackets IPv6 addresses

### DIFF
--- a/model/CentraRequest.js
+++ b/model/CentraRequest.js
@@ -108,7 +108,7 @@ module.exports = class CentraRequest {
 
 			const options = Object.assign({
 				'protocol': this.url.protocol,
-				'host': this.url.hostname,
+				'host': this.url.hostname.replace('[', '').replace(']', ''),
 				'port': this.url.port,
 				'path': this.url.pathname + (this.url.search === null ? '' : this.url.search),
 				'method': this.method,


### PR DESCRIPTION
This will allow `phin` and `pactum` to both use IPv6 addresses in their calls. Useful for when NestJS's `app.getUrl()` returns `http://[::1]:3000` or similar. This should not impact anything else, as `[` and `]` are invalid host characters otherwise

fix #14